### PR TITLE
catima_calculator can have energy steps less than 1 MeV/u

### DIFF
--- a/bin/catima_calculator.cpp
+++ b/bin/catima_calculator.cpp
@@ -82,7 +82,7 @@ int main( int argc, char * argv[] )
                         double emax = e["max"].get<double>();
                         int num=0;
                         if(e.count("step")){
-                            num = 1+(emax-emin)/e["step"].get<int>();
+                            num = 1+(emax-emin)/e["step"].get<double>();
                         }
                         if(e.count("num")){
                             num = e["num"].get<int>();


### PR DESCRIPTION
catima_calculator energy step is extracted using get\<int\>, but there's no reason to restrict energy steps to multiples of 1MeV/u - they could reasonably be smaller, or be larger and non-integer using get\<double\>. e.g.
"energy": { "min": 50, "max": 1000, "step": 2.5 }
or
"energy":{"min": 0.1, "max":50, "step": 0.1 }